### PR TITLE
Stop deleting the original message

### DIFF
--- a/modules/factoids/factoids.go
+++ b/modules/factoids/factoids.go
@@ -79,7 +79,6 @@ func RunCommand(ds *discordgo.Session, mc *discordgo.MessageCreate, cmd string, 
 	}
 
 	_, err = ds.ChannelMessageSend(mc.ChannelID, ">>> "+msg)
-	_ = ds.ChannelMessageDelete(mc.ChannelID, mc.ID)
 }
 
 type factoid struct {

--- a/modules/factoids/factoids.go
+++ b/modules/factoids/factoids.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lordralex/absol/api"
 	"github.com/lordralex/absol/api/logger"
 	"github.com/lordralex/absol/core/database"
+	"github.com/spf13/viper"
 	"strings"
 )
 
@@ -20,6 +21,7 @@ func (*Module) Load(ds *discordgo.Session) {
 }
 
 func RunCommand(ds *discordgo.Session, mc *discordgo.MessageCreate, cmd string, args []string) {
+	shouldDelete := viper.GetBoolean("factoid.delete")
 	if len(args) == 0 {
 		return
 	}
@@ -79,6 +81,9 @@ func RunCommand(ds *discordgo.Session, mc *discordgo.MessageCreate, cmd string, 
 	}
 
 	_, err = ds.ChannelMessageSend(mc.ChannelID, ">>> "+msg)
+	if shouldDelete {
+		_ = ds.ChannelMessageDelete(mc.ChannelID, mc.ID)
+	}
 }
 
 type factoid struct {


### PR DESCRIPTION
Stop deleting the original message when triggering a factoid
This makes it easier for the user to know that they have to follow the instructions(as they see the person helping him triggering it) and for us to know who triggered a specific factoid