### PR TITLE
Split HJT detections by newlines

### DIFF
--- a/modules/hjt/hjt.go
+++ b/modules/hjt/hjt.go
@@ -51,7 +51,7 @@ func RunCommand(ds *discordgo.Session, mc *discordgo.MessageCreate, cmd string, 
 	if len(values) == 0 {
 		_, err = ds.ChannelMessageSend(mc.ChannelID, "No matches found")
 	} else {
-		_, err = ds.ChannelMessageSend(mc.ChannelID, strings.Join(values, ", "))
+		_, err = ds.ChannelMessageSend(mc.ChannelID, strings.Join(values, ",\n"))
 	}
 }
 


### PR DESCRIPTION
I think that for logs with many detections, having each on its own line would greatly improve readability. I find it much easier to distinguish list items with a newline compared to just a comma, and I don't think I'm alone in that.